### PR TITLE
Fix typos in documentation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Refreshed the OpenAPI yml spec `openapi/spec.yml` to be based on the latest Connect API design.
 - Patch and minor version changes to package dependencies in the `ecommerce_shop` and `playground` demos.
 - Moved `webpack.config.cjs` to `webpack.config.ts` for type checking.
-- Updated file name casing to be consistent, and added an elint rule to enforce this
+- Updated file name casing to be consistent, and added an eslint rule to enforce this
 - Updated `eslint`, `eslint-plugin-unicorn`, and `typescript-eslint`.
 
 ## 2024-12-19
@@ -21,7 +21,7 @@
 
 - Both demo projects now take advantage of the CORS support for the Connect API and make most requests directly from the frontend code
 - Updated HeyAPI to version 0.5, and TypeScript to version 5.5
-- Dependencies are now pinned to exact versions to reduce accidental incompatabilities
+- Dependencies are now pinned to exact versions to reduce accidental incompatibilities
 - Refreshed the OpenAPI yml spec `openapi/spec.yml` to be based on the latest Connect API design
 
 ## 2024-09-23

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repo contains our openAPI specifications, as well as a demo ecommerce web a
 
 The Canva Connect API doesn't maintain nor publish client SDKs, however, we have made our [OpenAPI spec](./openapi/spec.yml) publicly available, so you can use it with your favorite code generation library, such as [openapi-generator](https://github.com/OpenAPITools/openapi-generator) to generate client SDKs in your language of choice!
 
-To demonstrate this, we're using [openapi-ts](https://www.npmjs.com/package/@hey-api/openapi-ts) to generate TypeScript SDKs in [client/ts](./client//ts/) which is used in our demo app.
+To demonstrate this, we're using [openapi-ts](https://www.npmjs.com/package/@hey-api/openapi-ts) to generate TypeScript SDKs in [client/ts](./client/ts/) which is used in our demo app.
 
 ## Demos: E-commerce Shop
 
@@ -63,7 +63,7 @@ cd demos/ecommerce_shop
 
 2. Add your integration settings to the `demos/ecommerce_shop/.env` file.
 
-- `DATABASE_ENCRYPTION_KEY`: This will encrypt and decrypt the tokens stored in the JSON database. A key is automatically get generated for you after running `npm install`, and will already be set in `.env`. If not, run `npm run generate:db-key` from the `demos/ecommerce_shop` directory.
+- `DATABASE_ENCRYPTION_KEY`: This will encrypt and decrypt the tokens stored in the JSON database. A key is automatically generated for you after running `npm install`, and will already be set in `.env`. If not, run `npm run generate:db-key` from the `demos/ecommerce_shop` directory.
 - `CANVA_CLIENT_ID`: This is the `Client ID` from the prerequisites.
 - `CANVA_CLIENT_SECRET`: This is the `client secret` you generated in the prerequisites.
 
@@ -113,7 +113,7 @@ cd demos/playground
 
 2. Add your integration settings to the `demos/playground/.env` file.
 
-- `DATABASE_ENCRYPTION_KEY`: This will encrypt and decrypt the tokens stored in the JSON database. A key is automatically get generated for you after running `npm install`, and will aready be set in `.env`.
+- `DATABASE_ENCRYPTION_KEY`: This will encrypt and decrypt the tokens stored in the JSON database. A key is automatically generated for you after running `npm install`, and will already be set in `.env`.
 - `CANVA_CLIENT_ID`: This is the `Client ID` from the prerequisites.
 - `CANVA_CLIENT_SECRET`: This is the `client secret` you generated in the prerequisites.
 


### PR DESCRIPTION
This PR fixes several typos found in the documentation files:

**CHANGELOG.md:**
- Fixed 'elint' → 'eslint'
- Fixed 'incompatabilities' → 'incompatibilities'
- Fixed 'get generated' → 'generated'

**README.md:**
- Fixed double slash in path: 'client//ts/' → 'client/ts/'
- Fixed 'get generated' → 'generated'
- Fixed 'aready' → 'already'

These corrections improve the overall documentation quality and readability.